### PR TITLE
Updating core ontology prefixes

### DIFF
--- a/swipl/client.pl
+++ b/swipl/client.pl
@@ -97,8 +97,8 @@ build_query_url(Server, User, DB, Query_url) :-        % Needs recoding to handl
   non_null('User', User),
   non_null('Database', DB),
   (ends_with(Server, '/')
-  -> atomic_list_concat([Server, 'woql/', User, '/', DB, '/local/branch/master'], Query_url)
-  ;  atomic_list_concat([Server, '/woql/', User, '/', DB, '/local/branch/master'], Query_url)).
+  -> atomic_list_concat([Server, 'woql/', User, '/', DB, '/local/branch/main'], Query_url)
+  ;  atomic_list_concat([Server, '/woql/', User, '/', DB, '/local/branch/main'], Query_url)).
 
 
 % build_graph_URL(+Server, +User, +DB, +GType, +GId, -Graph_URI)
@@ -109,8 +109,8 @@ build_graph_URL(Server, User, DB, GType, GId, Graph_URI) :-
   non_null('Graph type', GType),
   non_null('Graph ID', GId),
   (ends_with(Server, '/')
-  -> atomic_list_concat([Server, 'graph/', User, '/', DB, '/local/branch/master/schema/main'], Graph_URI)
-  ;  atomic_list_concat([Server, '/graph/', User, '/', DB, '/local/branch/master/schema/main'], Graph_URI)).
+  -> atomic_list_concat([Server, 'graph/', User, '/', DB, '/local/branch/main/schema/main'], Graph_URI)
+  ;  atomic_list_concat([Server, '/graph/', User, '/', DB, '/local/branch/main/schema/main'], Graph_URI)).
 
 
 

--- a/swipl/client.pl
+++ b/swipl/client.pl
@@ -69,13 +69,13 @@ get_key_with_default(Key, Dict, Default, X) :-
 % build_DB_URI(+Server, +User, +DB, -DB_URI)
 build_DB_URI(Server, User, DB, DB_URI) :-
   (ends_with(Server, '/')
-  -> atomic_list_concat([Server, 'db/', User, '/', DB], DB_URI)
-  ;  atomic_list_concat([Server, '/db/', User, '/', DB], DB_URI)).
+  -> atomic_list_concat([Server, 'api/db/', User, '/', DB], DB_URI)
+  ;  atomic_list_concat([Server, '/api/db/', User, '/', DB], DB_URI)).
 
 
 % build_DB_URI2(+Server, +DB, +EndPoint, -DB_URI)
 build_DB_URI2(Server, DB, EndPoint, DB_URI) :-
-  atomic_list_concat([DB, '/', EndPoint], Path),
+  atomic_list_concat([DB, '/api/', EndPoint], Path),
   build_DB_URI(Server, Path, DB_URI).
 
 
@@ -97,8 +97,8 @@ build_query_url(Server, User, DB, Query_url) :-        % Needs recoding to handl
   non_null('User', User),
   non_null('Database', DB),
   (ends_with(Server, '/')
-  -> atomic_list_concat([Server, 'woql/', User, '/', DB, '/local/branch/main'], Query_url)
-  ;  atomic_list_concat([Server, '/woql/', User, '/', DB, '/local/branch/main'], Query_url)).
+  -> atomic_list_concat([Server, 'api/woql/', User, '/', DB, '/local/branch/main'], Query_url)
+  ;  atomic_list_concat([Server, '/api/woql/', User, '/', DB, '/local/branch/main'], Query_url)).
 
 
 % build_graph_URL(+Server, +User, +DB, +GType, +GId, -Graph_URI)
@@ -109,8 +109,8 @@ build_graph_URL(Server, User, DB, GType, GId, Graph_URI) :-
   non_null('Graph type', GType),
   non_null('Graph ID', GId),
   (ends_with(Server, '/')
-  -> atomic_list_concat([Server, 'graph/', User, '/', DB, '/local/branch/main/schema/main'], Graph_URI)
-  ;  atomic_list_concat([Server, '/graph/', User, '/', DB, '/local/branch/main/schema/main'], Graph_URI)).
+  -> atomic_list_concat([Server, 'api/graph/', User, '/', DB, '/local/branch/main/schema/main'], Graph_URI)
+  ;  atomic_list_concat([Server, '/api/graph/', User, '/', DB, '/local/branch/main/schema/main'], Graph_URI)).
 
 
 
@@ -209,7 +209,8 @@ Cli.connect(Result) := client{ac: A, ctxt: C, db: D, url:X, user:Y, key:Z} :-
     (var(Result)
     -> true
     ;  logging:fatal('\'connect\' requires an unbound argument..')),
-    dispatch(Cli, Cli.url, 'connect', {}, Result, ''),
+    atomic_list_concat([Cli.url, '/api'], URL),
+    dispatch(Cli, URL, 'connect', {}, Result, ''),
     extract_context(Result, C),
     A = Cli.ac, D = Cli.db, X = Cli.url, Y = Cli.user, Z = Cli.key.
 

--- a/swipl/swoql.pl
+++ b/swipl/swoql.pl
@@ -55,13 +55,13 @@ vocabulary(_{
     'Class': 'owl:Class',
     'DatatypeProperty': 'owl:DatatypeProperty',
     'ObjectProperty': 'owl:ObjectProperty',
-    'Entity': 'tcs:Entity',
-    'Document': 'tcs:Document',
-    'Relationship': 'tcs:Relationship',
-    'temporality': 'tcs:temporality',
-    'geotemporality': 'tcs:geotemporality',
-    'geography': 'tcs:geography',
-    'abstract': 'tcs:abstract',
+    'Entity': 'system:Entity',
+    'Document': 'system:Document',
+    'Relationship': 'system:Relationship',
+    'temporality': 'system:temporality',
+    'geotemporality': 'system:geotemporality',
+    'geography': 'system:geography',
+    'abstract': 'system:abstract',
     'comment': 'rdfs:comment',
     'range': 'rdfs:range',
     'domain': 'rdfs:domain',
@@ -103,8 +103,8 @@ begins_with_reserved_colon(S) :-
    (begins_with_pattern_colon(S, rdfs);
     begins_with_pattern_colon(S, rdf);
     begins_with_pattern_colon(S, owl);
-    begins_with_pattern_colon(S, tcs);
-    begins_with_pattern_colon(S, terminus);
+    begins_with_pattern_colon(S, api);
+    begins_with_pattern_colon(S, system);
     begins_with_pattern_colon(S, xsd);
     begins_with_pattern_colon(S, xdd)).
 
@@ -867,7 +867,7 @@ ask_doctype(ArgList, DictIn, DictOut) :-
   start_scope(doc, DocName, DictIn, Dict1),
   jsonise_scm(DocName, JDocName),
   do_ask(and([add_quad(JDocName, 'rdf:type', 'owl:Class', 'schema/main'),
-                add_quad(JDocName, 'rdfs:subClassOf', 'terminus:Document', 'schema/main')]),
+                add_quad(JDocName, 'rdfs:subClassOf', 'system:Document', 'schema/main')]),
            _, Dict1, Dict2),
   do_ask(Qualifier, _, Dict2, DictOut).
 
@@ -1516,17 +1516,17 @@ result_success(Result) :-
     -> true
     ;  logging:fatal('\'result_success\' requires a bound argument..')),
   result_to_dict(Result, Dict),
-  (is_dict(Dict)
-   -> (get_dict('terminus:status', Dict, Terminus_Result)
-      -> (Terminus_Result == "terminus:success"               %NB: have to use string quotes here,  not ''
-          -> true
-          ;  logging:info('\'terminus:status\' = \'~w\' in result ~w passed to \'result_success\'', [Terminus_Result, Result]),
-             false)
-      ;  (get_dict('terminus:agent_key_hash', Dict, _)
-          -> true                                  % Call was actually a 'connect',  and the result looks valid
-          ;  (get_dict('bindings', Dict, _)
-             -> logging:info('\'bindings\' received in result passed to \'result_success\': ~w', [Result])
-            ;   logging:info('Missing response in result passed to \'result_success\': ~w', [Result]),
-                false)))
-   ; logging:info('\'result_success\' has a non-dict result: ~w', [Result]),
-     false).
+  (   is_dict(Dict)
+  ->  (   get_dict('api:status', Dict, Terminus_Result)
+      ->  (   Terminus_Result == "api:success"               %NB: have to use string quotes here,  not ''
+          ->  true
+          ;   logging:info('\'api:status\' = \'~w\' in result ~w passed to \'result_success\'', [Terminus_Result, Result]),
+              false)
+      ;   (   get_dict('@type', Dict, "system:User")
+          ->  true                                  % Call was actually a 'connect',  and the result looks valid
+          ;   (   get_dict('bindings', Dict, _)
+              ->  logging:info('\'bindings\' received in result passed to \'result_success\': ~w', [Result])
+              ;   logging:info('Missing response in result passed to \'result_success\': ~w', [Result]),
+                  false)))
+   ;  logging:info('\'result_success\' has a non-dict result: ~w', [Result]),
+      false).


### PR DESCRIPTION
This merely updates some of the core ontology prefixes to reflect our (soon to be documented) core ontologies. 

This fix will make the tutorial run on TerminusDB v2.0.5 or greater but is not backward compatible with v2.0.4 and less. These versioning changes should have moved the major version number but unfortunately did not.

There are slight formatting changes which create a bit of a mixed message as most of the conditionals are to a house style, but I found it easier to read to understand what was going on. 